### PR TITLE
Allow for multiple possible validators

### DIFF
--- a/lib/compose.js
+++ b/lib/compose.js
@@ -1,4 +1,4 @@
-const { isOK, ok } = require('./result');
+const { isOK, ok, isErr, err } = require('./result');
 const {
   validateIsObject,
   validateIsArray,
@@ -13,15 +13,29 @@ const {
 } = require('./validators');
 
 /**
- * Compose a series of validators (left-to-right)
+ * Composes a series of validators (left-to-right) such that all of the
+ * validators must succeed. Otherwise, returns the first set of errors.
+ * All validators are passed the same schema and data
  */
-const compose = (...validators) => schema => data =>
+const allOf = (...validators) => schema => data =>
   validators.reduce((res, v) => (isOK(res) ? v(schema)(data) : res), ok());
+
+/**
+ * Composes a series of validators that are already applied to schemas,
+ * such that at least one of the validators must succeed. Otherwise, returns
+ * all of the errors
+ */
+const someOf = (...validatorsWithSchemas) => data =>
+  validatorsWithSchemas.reduce((res, v) => {
+    if (isOK(res)) return res;
+    const vRes = v(data);
+    return isErr(vRes) ? err([...res.errors, ...vRes.errors]) : vRes;
+  }, err());
 
 /**
  * Precomposed validator for objects
  */
-const objectValidator = compose(
+const objectValidator = allOf(
   validateIsObject,
   validateRequiredFields,
   validateExtraFields,
@@ -33,7 +47,7 @@ const objectValidator = compose(
 /**
  * Precomposed validator for arrays
  */
-const arrayValidator = compose(
+const arrayValidator = allOf(
   validateIsArray,
   validateItemsTypecheck,
   validateArrayPredicates,
@@ -41,7 +55,8 @@ const arrayValidator = compose(
 );
 
 module.exports = {
-  compose,
+  allOf,
+  someOf,
   objectValidator,
   arrayValidator,
 };

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -44,6 +44,7 @@ module.exports.validateExtraFields = schema => data =>
  */
 module.exports.validateFieldsTypecheck = schema => data =>
   Object.keys(data)
+    .filter(k => schema[k] && schema[k].hasOwnProperty('type'))
     .filter(k => !typechecks(data[k], schema[k].type))
     .map(k => `Field "${k}" failed to typecheck (expected ${schema[k].type})`)
     .toResult();

--- a/test/validators.spec.js
+++ b/test/validators.spec.js
@@ -147,6 +147,7 @@ describe('validators', () => {
       field2: {
         type: 'number',
       },
+      field3: {},
     };
 
     const validate = validateFieldsTypecheck(schema);
@@ -177,6 +178,18 @@ describe('validators', () => {
       });
       expect(isOK(res)).to.be.true;
       expect(res.errors).to.deep.equal([]);
+    });
+
+    it("should return an OK for fields that don't specify a type", () => {
+      const res1 = validate({
+        field3: 'a string',
+      });
+      expect(isOK(res1)).to.be.true;
+
+      const res2 = validate({
+        field3: 123,
+      });
+      expect(isOK(res2)).to.be.true;
     });
   });
 


### PR DESCRIPTION
- Add `someOf()` composer function
- Rename `compose()` to `allOf()` for clarity
- Make the `type` schema field optional and change `validateFieldsTypecheck()` accordingly

The motivation here is to allow us to write something like the following:

```js
const schema = {
  field1: {
    schemaValidator: someOf(
      objectValidator(objectSchema),
      arrayValidator(arraySchema)
    ),
  },
};
```

This means `field1` can match either the `objectSchema`, the `arraySchema`, or both. Of course, any schemas and validators can be used here, not just the ones exported by default.

The only weirdness / inconsistency is that `allOf` accepts functions of the type `schema => data => validator` and produces the same, but `someOf` accepts functions of the type `data => validator` and produces the same. This is necessary because each possible validator inside `someOf` is going to match against a different schema, so they need to already be partially applied. Thoughts are welcome on this.

Once we're agreed I'll update the README and bump the version.