### PR TITLE
Make ISO8601 regex more lenient

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -10,7 +10,7 @@
 const isISOString = str =>
   typeof str === 'string' &&
   str.match(
-    /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z)/
+    /^\d{4}(-\d\d(-\d\d(T\d\d:\d\d(:\d\d)?(\.\d+)?(([+-]\d\d:\d\d)|Z)?)?)?)?$/i
   ) !== null;
 
 /**

--- a/test/helpers.spec.js
+++ b/test/helpers.spec.js
@@ -18,11 +18,13 @@ describe('helpers', () => {
 
     it('should fail for non-ISO strings', () => {
       expect(isISOString('boo')).to.be.false;
-      expect(isISOString('2017-05-03')).to.be.false;
+      expect(isISOString('2017-05XYZ-03')).to.be.false;
       expect(isISOString('16:12:18.554Z')).to.be.false;
     });
 
     it('should succeed for ISO strings', () => {
+      expect(isISOString('2017-05-03')).to.be.true;
+      expect(isISOString('2017-05-03T16:12:18.554+01:00')).to.be.true;
       expect(isISOString('2017-05-03T16:12:18.554Z')).to.be.true;
     });
   });
@@ -36,12 +38,13 @@ describe('helpers', () => {
     });
 
     it('should fail for non-ISO strings', () => {
-      expect(isDate('2017-05-03')).to.be.false;
+      expect(isDate('2017-05XYZ-03')).to.be.false;
       expect(isDate('16:12:18.554Z')).to.be.false;
     });
 
     it('should succeed for dates or ISO strings', () => {
       expect(isDate(new Date())).to.be.true;
+      expect(isDate('2017-05-03')).to.be.true;
       expect(isDate('2017-05-03T16:12:18.554Z')).to.be.true;
     });
   });


### PR DESCRIPTION
I say more lenient; the spec allows for the time part of the timestamp to be optional, so this is really more _correct_.